### PR TITLE
Replace non-standard pthread_yield with sched_yield

### DIFF
--- a/Core/src/ThreadPThread.cpp
+++ b/Core/src/ThreadPThread.cpp
@@ -24,10 +24,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <errno.h>
-
-#ifdef __APPLE__
 #include <sched.h>
-#endif
 
 static void ReportErrorAndExit(int err, const char *msg) {
   char errMsg[1024];
@@ -101,13 +98,9 @@ void TCThread::Join() {
 #undef Yield
 #endif
 void TCThread::Yield() {
-#if defined(__APPLE__) || defined(__MINGW32__)
   int result = sched_yield();
-#else
-  int result = pthread_yield();
-#endif
   if(result != 0) {
-    ReportErrorAndExit(result, "pthread_yield");
+    ReportErrorAndExit(result, "sched_yield");
   }
 }
 


### PR DESCRIPTION
pthread_yield is not compatible with environments like Alpine Linux. Furthermore, this function seems to be implemented as a call to sched_yield on most Linux systems. The man page recommends the use of sched_yield instead [1].

[1] https://linux.die.net/man/3/pthread_yield